### PR TITLE
Revert "TSBM-136 Removed time support defined by platform. Use default."

### DIFF
--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -119,17 +119,12 @@ uint64_t GetClock_MonotonicHiRes(void)
 
 CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
 {
-    // TODO(19081): This platform does not properly error out if wall clock has
-    //              not been set.  For now, short circuit this.
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#if 0
     if (sBootTimeUS == 0)
     {
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     aCurTime = Clock::Microseconds64(sBootTimeUS + GetClock_Monotonic());
     return CHIP_NO_ERROR;
-#endif
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)

--- a/src/platform/renesas/BUILD.gn
+++ b/src/platform/renesas/BUILD.gn
@@ -41,6 +41,8 @@ static_library("renesas") {
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
     "SystemPlatformConfig.h",
+    "SystemTimeSupport.h",
+    "SystemTimeSupport.cpp",
   ]
 
   defines = [ "CHIP_SYSTEM_CONFIG_USE_LWIP=1", "FSL_RTOS_FREE_RTOS=1" ]

--- a/src/platform/renesas/SystemTimeSupport.cpp
+++ b/src/platform/renesas/SystemTimeSupport.cpp
@@ -1,0 +1,172 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides implementations of the CHIP System Layer platform
+ *          time/clock functions based on the FreeRTOS tick counter.
+ */
+/* this file behaves like a config.h, comes first */
+#include <time.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include "time_zone.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace chip {
+namespace System {
+namespace Clock {
+
+namespace Internal {
+ClockImpl gClockImpl;
+} // namespace Internal
+
+namespace {
+
+constexpr uint32_t kTicksOverflowShift = (configUSE_16_BIT_TICKS) ? 16 : 32;
+
+uint64_t sBootTimeUS = 0;
+
+#ifdef __CORTEX_M
+BaseType_t sNumOfOverflows;
+#endif
+} // unnamed namespace
+
+/**
+ * Returns the number of FreeRTOS ticks since the system booted.
+ *
+ * NOTE: The default implementation of this function uses FreeRTOS's
+ * vTaskSetTimeOutState() function to get the total number of ticks,
+ * irrespective of tick counter overflows.  Unfortunately, this function cannot
+ * be called in interrupt context, no equivalent ISR function exists, and
+ * FreeRTOS provides no portable way of determining whether a function is being
+ * called in an interrupt context.  Adaptations that need to use the Chip
+ * Get/SetClock methods from within an interrupt handler must override this
+ * function with a suitable alternative that works on the target platform.  The
+ * provided version is safe to call on ARM Cortex platforms with CMSIS
+ * libraries.
+ */
+
+uint64_t FreeRTOSTicksSinceBoot(void) __attribute__((weak));
+
+uint64_t FreeRTOSTicksSinceBoot(void)
+{
+    TimeOut_t timeOut;
+
+#ifdef __CORTEX_M
+    if (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) // running in an interrupt context
+    {
+        // Note that sNumOverflows may be quite stale, and under those
+        // circumstances, the function may violate monotonicity guarantees
+        timeOut.xTimeOnEntering = xTaskGetTickCountFromISR();
+        timeOut.xOverflowCount  = sNumOfOverflows;
+    }
+    else
+    {
+#endif
+
+        vTaskSetTimeOutState(&timeOut);
+
+#ifdef __CORTEX_M
+        // BaseType_t is supposed to be atomic
+        sNumOfOverflows = timeOut.xOverflowCount;
+    }
+#endif
+
+    return static_cast<uint64_t>(timeOut.xTimeOnEntering) + (static_cast<uint64_t>(timeOut.xOverflowCount) << kTicksOverflowShift);
+}
+
+Clock::Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
+{
+    return Clock::Microseconds64((FreeRTOSTicksSinceBoot() * kMicrosecondsPerSecond) / configTICK_RATE_HZ);
+}
+
+Clock::Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
+{
+    return Clock::Milliseconds64((FreeRTOSTicksSinceBoot() * kMillisecondsPerSecond) / configTICK_RATE_HZ);
+}
+
+uint64_t GetClock_Monotonic(void)
+{
+    return (FreeRTOSTicksSinceBoot() * kMicrosecondsPerSecond) / configTICK_RATE_HZ;
+}
+
+uint64_t GetClock_MonotonicMS(void)
+{
+    return (FreeRTOSTicksSinceBoot() * kMillisecondsPerSecond) / configTICK_RATE_HZ;
+}
+
+uint64_t GetClock_MonotonicHiRes(void)
+{
+    return GetClock_Monotonic();
+}
+
+CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
+{
+    // TODO(19081): This platform does not properly error out if wall clock has
+    //              not been set.  For now, short circuit this.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#if 0
+    if (sBootTimeUS == 0)
+    {
+        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+    }
+    aCurTime = Clock::Microseconds64(sBootTimeUS + GetClock_Monotonic());
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
+{
+    struct m_timeval tv;
+    clock_gettime(&tv);
+    aCurTime = std::chrono::seconds(tv.tv_sec) + std::chrono::milliseconds(tv.tv_usec/1000);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+{
+    uint64_t timeSinceBootUS = GetClock_Monotonic();
+    if (aNewCurTime.count() > timeSinceBootUS)
+    {
+        sBootTimeUS = aNewCurTime.count() - timeSinceBootUS;
+    }
+    else
+    {
+        sBootTimeUS = 0;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR InitClock_RealTime()
+{
+    Clock::Microseconds64 curTime =
+        Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
+    // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
+    // Then the RealTime obtained from GetClock_RealTime will be always valid.
+    //
+    // TODO(19081): This is broken because it causes the platform to report
+    //              that it does have wall clock time when it actually doesn't.
+    return System::SystemClock().SetClock_RealTime(curTime);
+}
+
+} // namespace Clock
+} // namespace System
+} // namespace chip

--- a/src/platform/renesas/SystemTimeSupport.cpp
+++ b/src/platform/renesas/SystemTimeSupport.cpp
@@ -42,8 +42,6 @@ namespace {
 
 constexpr uint32_t kTicksOverflowShift = (configUSE_16_BIT_TICKS) ? 16 : 32;
 
-uint64_t sBootTimeUS = 0;
-
 #ifdef __CORTEX_M
 BaseType_t sNumOfOverflows;
 #endif
@@ -120,51 +118,35 @@ uint64_t GetClock_MonotonicHiRes(void)
 
 CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
 {
-    // TODO(19081): This platform does not properly error out if wall clock has
-    //              not been set.  For now, short circuit this.
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#if 0
-    if (sBootTimeUS == 0)
+    struct m_timeval tv;
+    if (clock_gettime(&tv) == 0)
     {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+        aCurTime = std::chrono::seconds(tv.tv_sec) + std::chrono::microseconds(tv.tv_usec);
+        return CHIP_NO_ERROR;
     }
-    aCurTime = Clock::Microseconds64(sBootTimeUS + GetClock_Monotonic());
-    return CHIP_NO_ERROR;
-#endif
+    return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
+
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
 {
-    struct m_timeval tv;
-    clock_gettime(&tv);
-    aCurTime = std::chrono::seconds(tv.tv_sec) + std::chrono::milliseconds(tv.tv_usec/1000);
-    return CHIP_NO_ERROR;
+    Clock::Microseconds64 time_us;
+    auto result = GetClock_RealTime(time_us);
+    if (result == CHIP_NO_ERROR)
+    {
+        aCurTime = std::chrono::duration_cast<Clock::Milliseconds64>(time_us);
+    }
+    return result;
 }
 
 CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
 {
-    uint64_t timeSinceBootUS = GetClock_Monotonic();
-    if (aNewCurTime.count() > timeSinceBootUS)
-    {
-        sBootTimeUS = aNewCurTime.count() - timeSinceBootUS;
-    }
-    else
-    {
-        sBootTimeUS = 0;
-    }
-    return CHIP_NO_ERROR;
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 CHIP_ERROR InitClock_RealTime()
 {
-    Clock::Microseconds64 curTime =
-        Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
-    // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
-    // Then the RealTime obtained from GetClock_RealTime will be always valid.
-    //
-    // TODO(19081): This is broken because it causes the platform to report
-    //              that it does have wall clock time when it actually doesn't.
-    return System::SystemClock().SetClock_RealTime(curTime);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Clock

--- a/src/platform/renesas/SystemTimeSupport.h
+++ b/src/platform/renesas/SystemTimeSupport.h
@@ -1,7 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
- *    Copyright (c) 2019 Google LLC.
+ *    Copyright (c) 2022 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,17 +15,14 @@
  *    limitations under the License.
  */
 
-/**
- * @file
- * Platform-specific configuration overrides for the CHIP system layer.
- *
- */
+#include <lib/support/TimeUtils.h>
 
-#pragma once
+namespace chip {
+namespace System {
+namespace Clock {
 
-// ==================== Platform Adaptations ====================
-#define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 1
-#define CHIP_SYSTEM_CONFIG_EVENT_OBJECT_TYPE const struct ::chip::DeviceLayer::ChipDeviceEvent *
-#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 0
+CHIP_ERROR InitClock_RealTime();
 
-// ========== Platform-specific Configuration Overrides =========
+} // namespace Clock
+} // namespace System
+} // namespace chip


### PR DESCRIPTION
This reverts commit 7981f93f86eeba182d50cc2671d121241f453aea.

