### PR TITLE
Fix python dependencies for python 3.12/ubuntu 24

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -49,7 +49,7 @@ colorama==0.4.6
     #   west
 coloredlogs==15.0.1
     # via -r requirements.all.txt
-construct==2.10.54
+# construct==2.10.54
     # via
     #   -r requirements.esp32.txt
     #   esp-coredump
@@ -134,7 +134,7 @@ mypy-extensions==1.0.0
     # via mypy
 mypy-protobuf==3.5.0
     # via -r requirements.all.txt
-numpy==1.24.2
+numpy==2.1.0
     # via pandas
 packaging==23.0
     # via
@@ -208,7 +208,7 @@ python-socketio==4.6.1
     # via -r requirements.esp32.txt
 pytz==2022.7.1
     # via pandas
-pyyaml==6.0
+pyyaml==6.0.2
     # via
     #   esptool
     #   idf-component-manager

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -39,8 +39,8 @@ coloredlogs
 watchdog
 build==0.8.0
 mypy==0.971
-mypy-protobuf==3.5.0
-protobuf==4.24.4
+mypy-protobuf
+protobuf
 types-protobuf==4.24.0.2
 
 cryptography

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -8,7 +8,7 @@ pygdbmi<=0.9.0.2
 reedsolo>=1.5.3,<=1.5.4
 bitstring>=3.1.6,<4
 ecdsa>=0.16.0
-construct==2.10.54
+construct==2.10.70
 python-socketio<5
 itsdangerous<2.1 ; python_version < "3.11"
 esp_idf_monitor==1.1.1


### PR DESCRIPTION
These changes helped my built with a newer python. Especially the `boostrap.sh` script failed with quite a few python dependency failures because of deprecated packages and so on. 

This does NOT have to be merged until everyone is on python 3.12. If CHIP itself becomes 2024 compatible then there'll probably be a more subtle fix in upstream. 

For now I'm just storing this branch as a patch for myself or others with this dependency problem.
 