### PR TITLE
TSBM-317 Override pairinghints since they must not appear according to spec.

### DIFF
--- a/src/platform/renesas/ConfigurationManagerImpl.cpp
+++ b/src/platform/renesas/ConfigurationManagerImpl.cpp
@@ -262,6 +262,16 @@ CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t
     return CHIP_ERROR_INTERNAL;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetInitialPairingInstruction(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetSecondaryPairingInstruction(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 ConfigurationManager & ConfigurationMgrImpl()
 {
     return ConfigurationManagerImpl::GetDefaultInstance();

--- a/src/platform/renesas/ConfigurationManagerImpl.h
+++ b/src/platform/renesas/ConfigurationManagerImpl.h
@@ -49,6 +49,8 @@ public:
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetInitialPairingInstruction(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetSecondaryPairingInstruction(char * buf, size_t bufSize) override;
     void RegisterInformationProvider(ConfigurationInformationProvider& provider);
 private:
     ConfigurationManagerImpl();


### PR DESCRIPTION
```
This key/value (read: PI)
pair SHALL only be
returned in the DNS-SD TXT
record if the PH bitmap
value has a bit set which has
PI Dependency = True, see
Table 6, "Pairing Hint
Values".
```
It was empty ("PI=") before.
